### PR TITLE
Changing Subtitle

### DIFF
--- a/encryption_works.md
+++ b/encryption_works.md
@@ -1,4 +1,4 @@
-# Encryption Works: How to Protect Your Privacy in the Age of NSA Surveillance
+# Encryption Works: A Guide to Protecting Your Privacy for Journalists, Sources, and Everyone Else
 
 <style>
 div#out-of-date {


### PR DESCRIPTION
_Encryption Works_ 1.0 was titled *Encryption Works: How to Protect Your Privacy in the Age of NSA Surveillance*. I think that the guide is geared toward a larger audience than just people who are worried specifically about the NSA -- good passphrase knowledge, two-factor auth, etc. will prevent against fitting attacks and social engineering, which is something journalists (and others) have to protect against. 

With all that in mind, my proposed title for the updated _Encryption Works_ is: *Encryption Works: A Guide to Protecting Your Privacy for Journalists, Sources, and Everyone Else.*

(As per https://github.com/freedomofpress/encryption-works/issues/61)