### PR TITLE
OTR: Rip out client software section & replace with link to Intercept

### DIFF
--- a/encryption_works.md
+++ b/encryption_works.md
@@ -130,11 +130,9 @@ Using OTR only encrypts the contents of your chat conversations but not the meta
 
 I also recommend you use an XMPP (also known as Jabber) service. Like email, Jabber is a federated, open protocol. Users of [riseup.net](https://www.riseup.net/en/chat)'s Jabber service can chat with users of [jabber.ccc.de](https://web.jabber.ccc.de/)'s service as well as [jabber.org](http://www.jabber.org/)'s service.
 
-### OTR Clients
+## Using OTR
 
-To use OTR you'll need to download software. If you use Windows you can download and install [Pidgin](https://pidgin.im/) and separately the [OTR plugin](http://www.cypherpunks.ca/otr/). If you use GNU/Linux you can install the pidgin and pidgin-otr packages. You can read through [documentation on how to set up your Pidgin accounts with OTR](http://www.cypherpunks.ca/otr/index.php#docs). If you use Mac OS X you can download and install [Adium](http://adium.im/), which is a free software chat client that includes OTR support. You can read the [official documentation](http://adium.im/help/pgs/AdvancedFeatures-OTREncryption.html) on how to get set up with OTR encryption with Adium.
-
-There are also Jabber and OTR clients available for Android, called [Gibberbot](https://guardianproject.info/apps/gibber/), and for iOS, called [ChatSecure](http://chrisballinger.info/apps/chatsecure/).
+To use OTR, you'll need to download additional software with your IM client. For a full explanation of how it works and how to set it up, check out The Intercept's guide to [chatting in secret while we're all being watched](https://firstlook.org/theintercept/2015/07/14/communicating-secret-watched/).
 
 ### Your Key
 

--- a/encryption_works.md
+++ b/encryption_works.md
@@ -132,8 +132,9 @@ I also recommend you use an XMPP (also known as Jabber) service. Like email, Jab
 
 ## Using OTR
 
-To use OTR, you'll need to download additional software with your IM client. For a full explanation of how it works and how to set it up, check out The Intercept's guide to [chatting in secret while we're all being watched](https://firstlook.org/theintercept/2015/07/14/communicating-secret-watched/).
+To use OTR, you'll need to download additional software with your IM client. If you use Windows you can download and install [Pidgin](https://pidgin.im/) and the [OTR plugin](http://www.cypherpunks.ca/otr/). If you use GNU/Linux you can install the pidgin and pidgin-otr packages. If you use Mac OS X you can download and install [Adium](https://adium.im), a free software chat application that includes OTR support.
 
+For a full explanation of how it works and how to set it up, check out The Intercept's guide to [chatting in secret while we're all being watched](https://firstlook.org/theintercept/2015/07/14/communicating-secret-watched/).
 ### Your Key
 
 When you start using OTR, your chat client generates an encryption key and stores it in a file in your user's home folder on your hard drive. If your computer or smartphone get lost, stolen, or infected with malware, it's possible that your OTR key can get compromised. If this happens, it would be possible for an attacker with control over your Jabber server to be able to mount a MITM attack against you while you're chatting with people who have previously verified your identity.


### PR DESCRIPTION
In re: #69.

My vision of _Encryption Works_ is that it's a philosophical document describing these issues and exploring some of their nuances, but that when it comes down to how-tos, etc., it's better to link to external sources which a) are probably written better and b) take the pressure off us to update quite so often. 

With that in mind, and with my stated aim to reflect two years of Snowden revelations and news stories written in the intervening period between EW 1.0 and 2.0, my proposed change is just to rip out the section titled *OTR clients* and replace it with a section titled *Using OTR*.