### PR TITLE
Update Pronouns in OTR>logs section

### DIFF
--- a/encryption_works.md
+++ b/encryption_works.md
@@ -373,7 +373,7 @@ This approach wouldn't have worked when Edward Snowden first made contact with L
 
 OTR will encrypt the content of your chats, but there's another factor to consider when you're chatting with Off-The Record: logs.
 
-Here is an excerpt from the chat logs of a conversation between Chelsea Manning (shown here as bradass87) and Adrian Lamo, who turned him in to authorities. They were [published](http://www.wired.com/threatlevel/2011/07/manning-lamo-logs) by Wired.
+Here is an excerpt from the chat logs of a conversation between Chelsea Manning (shown here as bradass87) and Adrian Lamo, who turned her in to authorities. They were [published](http://www.wired.com/threatlevel/2011/07/manning-lamo-logs) by Wired.
 
 > (1:40:51 PM) bradass87 has not been authenticated yet. You should authenticate this buddy.
 


### PR DESCRIPTION
Micah wrote this before Chelsea's lawyer [released](http://www.theguardian.com/world/2013/aug/22/chelsea-manning-bradley-full-statement) a statement announcing that Manning requested a different name and pronouns than had previously appeared in media reports. I caught the name in my rewrite but missed a "he" mention. My bad.

Resolves #94.