### PR TITLE
word choice in first line

### DIFF
--- a/encryption_works.md
+++ b/encryption_works.md
@@ -569,7 +569,7 @@ In general, software websites have to provide the checksum for you to check, but
 
 ## Tails: The Amnesic Incognito Live System
 
-As mentioned above, the Tor network is the best choice today for secure web browsing: it obscures your location, prevents third-party trackers, and you can create a new browsing identity quickly and easily. What if there was an entire operating system designed with these principles in mind?
+As mentioned earlier, the Tor network is the best choice today for secure web browsing: it obscures your location, prevents third-party trackers, and you can create a new browsing identity quickly and easily. What if there was an entire operating system designed with these principles in mind?
 
 That's the thinking behind the Tails system. PGP and OTR are totally undermined if an attacker has physically compromised your machine and, say, installed a keylogger to capture all your logins, passphrases, and other sensitive data.
 


### PR DESCRIPTION
"Above" only works if you're reading all in one go -- since these are chapters/sections, "earlier" is probably more correct.