### PR TITLE
Remove Comma From Editor List

### DIFF
--- a/encryption_works.md
+++ b/encryption_works.md
@@ -2,7 +2,7 @@
 
 ### August 2015
 
-### Originally written by Micah Lee. Updated version written by Tommy Collison and edited by Harlo Holmes, and Garrett Robinson.
+### Originally written by Micah Lee. Updated version written by Tommy Collison and edited by Harlo Holmes and Garrett Robinson.
 
 *Dedicated to cypherpunks, and to whistleblowers past and future.*
 


### PR DESCRIPTION
Since there are now two names here rather than three, there's no need for the names to be separated by a comma. Removed.

Resolves #182.