### PR TITLE
Consolidate document heading

### DIFF
--- a/encryption_works.md
+++ b/encryption_works.md
@@ -5,7 +5,7 @@
 
 A publication of **Freedom of the Press Foundation**. Original version written by Micah Lee and published July 2013. Updated version written by Tommy Collison and published September 2015.
 
-Encryption Works: A Guide to Protecting Your Privacy for Journalists, Sources, and Everyone Else is licensed under a Creative Commons Attribution 3.0 Unported License. [https://creativecommons.org/licenses/by/3.0/](https://creativecommons.org/licenses/by/3.0/).
+Licensed as [Creative Commons Attribution 3.0 Unported](https://creativecommons.org/licenses/by/3.0/).
 
 If you're interested in contributing to Encryption Works, or have ideas for what this guide should cover, please check out the project on [GitHub](https://github.com/freedomofpress/encryption-works/blob/master/CONTRIBUTING.md).
 

--- a/encryption_works.md
+++ b/encryption_works.md
@@ -3,7 +3,7 @@
 
 *Dedicated to cypherpunks, and to whistleblowers past and future.*
 
-A publication of **Freedom of the Press Foundation**. Original version written by Micah Lee and published July 2013. Updated version written by Tommy Collison and published September 2015. Licensed as [Creative Commons Attribution 3.0 Unported](https://creativecommons.org/licenses/by/3.0/).
+A publication of [Freedom of the Press Foundation](https://freedom.press/). Original version written by Micah Lee and published July 2013. Updated version written by Tommy Collison and published September 2015. Licensed as [Creative Commons Attribution 3.0 Unported](https://creativecommons.org/licenses/by/3.0/).
 
 If you're interested in contributing to Encryption Works, or have ideas for what this guide should cover, please check out the project on [GitHub](https://github.com/freedomofpress/encryption-works/blob/master/CONTRIBUTING.md).
 

--- a/encryption_works.md
+++ b/encryption_works.md
@@ -1,4 +1,5 @@
-### Encryption Works: A Guide to Protecting Your Privacy for Journalists, Sources, and Everyone Else
+# Encryption Works
+## A Guide to Protecting Your Privacy for Journalists, Sources, and Everyone Else
 
 ### Originally written by Micah Lee. Updated version written by Tommy Collison and edited by Harlo Holmes and Garrett Robinson.
 

--- a/encryption_works.md
+++ b/encryption_works.md
@@ -3,9 +3,7 @@
 
 *Dedicated to cypherpunks, and to whistleblowers past and future.*
 
-A publication of **Freedom of the Press Foundation**. Original version written by Micah Lee and published July 2013. Updated version written by Tommy Collison and published September 2015.
-
-Licensed as [Creative Commons Attribution 3.0 Unported](https://creativecommons.org/licenses/by/3.0/).
+A publication of **Freedom of the Press Foundation**. Original version written by Micah Lee and published July 2013. Updated version written by Tommy Collison and published September 2015. Licensed as [Creative Commons Attribution 3.0 Unported](https://creativecommons.org/licenses/by/3.0/).
 
 If you're interested in contributing to Encryption Works, or have ideas for what this guide should cover, please check out the project on [GitHub](https://github.com/freedomofpress/encryption-works/blob/master/CONTRIBUTING.md).
 

--- a/encryption_works.md
+++ b/encryption_works.md
@@ -1,7 +1,5 @@
 ### Encryption Works: A Guide to Protecting Your Privacy for Journalists, Sources, and Everyone Else
 
-### August 2015
-
 ### Originally written by Micah Lee. Updated version written by Tommy Collison and edited by Harlo Holmes and Garrett Robinson.
 
 *Dedicated to cypherpunks, and to whistleblowers past and future.*

--- a/encryption_works.md
+++ b/encryption_works.md
@@ -1,11 +1,9 @@
 # Encryption Works
 ## A Guide to Protecting Your Privacy for Journalists, Sources, and Everyone Else
 
-### Originally written by Micah Lee. Updated version written by Tommy Collison and edited by Harlo Holmes and Garrett Robinson.
-
 *Dedicated to cypherpunks, and to whistleblowers past and future.*
 
-A publication of **Freedom of the Press Foundation**. Originally published July 2013, updated August 2015.
+A publication of **Freedom of the Press Foundation**. Original version written by Micah Lee and published July 2013. Updated version written by Tommy Collison and published September 2015.
 
 Encryption Works: A Guide to Protecting Your Privacy for Journalists, Sources, and Everyone Else is licensed under a Creative Commons Attribution 3.0 Unported License. [https://creativecommons.org/licenses/by/3.0/](https://creativecommons.org/licenses/by/3.0/).
 


### PR DESCRIPTION
The first several paragraph in the document are brutally formatted. These changes tidy things up a bit, making the title stand out, while still giving credit where credit is due. (See #186 for discussion on listing authorship.) 

If folks are amenable, I suggest even further minimizing of the license by calling it **CC BY 3.0** rather than **Creative Commons Attribution 3.0 Unported**. The longer version is submitted with this PR, since it's arguably clearer.
