### PR TITLE
Removes redundant Snowden quote.

### DIFF
--- a/encryption_works.md
+++ b/encryption_works.md
@@ -20,10 +20,6 @@ Edward Snowden’s NSA revelations have caused a sea change in how the world’s
 
 Journalists or ordinary citizens who have no prior technical skills may feel helpless when it comes to protecting themselves. But just as technology has enabled government surveillance—not just from the US, but also in Russia, China and beyond—it can also provide a shield to safeguard your communications more comprehensively than at any other time in history. 
 
-As Edward Snowden [famously said](http://www.theguardian.com/world/2013/jun/17/edward-snowden-nsa-files-whistleblower) shortly after he went public with his disclosures in June 2013: 
-
-> “Encryption works. Properly implemented strong crypto systems are one of the few things that you can rely on. Unfortunately, endpoint security is so terrifically weak that NSA can frequently find ways around it.”
-
 The goal of this guide is to explain—in easy-to-understand language the threats that you may face when communicating online, and many of the steps you can take to mitigate those threats using open-source software, tried-and-true digital security techniques, and encryption. In short, encryption works — this guide explains why, and how.
 
 It takes a bit of patience, but no matter your skill set, you can learn how to use encryption tools to better protect yourself when emailing, calling, texting, or using your computer even when you are not connected to the internet.


### PR DESCRIPTION
The "Encryption Works" quote by Ed is fantastic,
but listing it twice in as many paragraphs,
within breakout blockquotes, is madness.

Snips out the second appearance, favoring the first
as setting the theme for the document and explaining
the origin of the title.