### PR TITLE
Remove ChatSecure because OTR on mobile sucks

### DIFF
--- a/encryption_works.md
+++ b/encryption_works.md
@@ -281,8 +281,6 @@ The best way to end-to-end encrypt your instant messages is to use something cal
 
 To use OTR, you'll need to download additional software with your IM client. If you use Windows you can download and install [Pidgin](https://pidgin.im/) and the [OTR plugin](http://www.cypherpunks.ca/otr/). If you use Mac OS X you can download and install [Adium](https://adium.im), a free software chat application that includes OTR support. If you use GNU/Linux you can install the pidgin and pidgin-otr packages.
 
-The OTR client for [Android](https://play.google.com/store/apps/details?id=info.guardianproject.otr.app.im]) and [iOS devices](https://itunes.apple.com/us/app/chatsecure/id464200063) is called ChatSecure.
-
 For a full explanation of how OTR works and how to set it up, check out The Intercept's guide to [chatting in secret while we're all being watched](https://firstlook.org/theintercept/2015/07/14/communicating-secret-watched/). As an added bonus, The Intercept also explains how to set up OTR to work with Tor so you can keep your chats both anonymous and encrypted.
 
 As with PGP, which will be discussed in a later section, OTR is used for two things: **encrypting the contents** of real-time instant message conversations and **verifying the identity** of people you chat with. Identity verification is important, and something many OTR users neglect to do. While OTR is more user-friendly than other types of encryption, there are some things you should know about OTR to understand it fully and know what attacks against it are possible.


### PR DESCRIPTION
As discussed in #211, OTR on mobile sucks and shouldn't really be recommended.
Further, XMPP in general should be phased out from our guide in favor of Signal
and Tor Messenger.

Signed-off-by: Noah Vesely <fowlslegs@riseup.net>